### PR TITLE
Bar Chart Now With Navigational Buttons

### DIFF
--- a/.idea/visual-trace-debugger.iml
+++ b/.idea/visual-trace-debugger.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4" />

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/SBFLScoreBarRenderer.java
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/SBFLScoreBarRenderer.java
@@ -10,6 +10,8 @@ public class SBFLScoreBarRenderer extends XYBarRenderer {
     private float lowestScore;
     private float highestScore;
     private float[] scores;
+    public int scstart;
+    public int scend;
 
     public SBFLScoreBarRenderer(float lowestScore, float highestScore, float[] scores) {
         this.lowestScore = lowestScore;
@@ -20,8 +22,9 @@ public class SBFLScoreBarRenderer extends XYBarRenderer {
 
     public Paint getItemPaint(final int row, final int column) {
         // returns color depending on score, if existing
-        if (column >= 0 && column < scores.length) {
-            return getColor(scores[column]);
+        //enriklau: has been modified to update the colors accordingly when changing the view
+        if (column >= 0 && column < scend) {
+            return getColor(scores[scstart+column]);
         } else {
             return Color.BLUE;
         }

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/TraceWindow.form
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/TraceWindow.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="se.de.hu_berlin.informatik.vtdbg.coverage.view.TraceWindow">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="552" height="460"/>
+      <xy x="20" y="20" width="603" height="464"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <tabbedpane id="34665" binding="tabs">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="200" height="200"/>
           </grid>
         </constraints>
@@ -20,7 +20,7 @@
       </tabbedpane>
       <component id="3e3df" class="javax.swing.JButton" binding="buttonLeft">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="previous"/>
@@ -28,10 +28,42 @@
       </component>
       <component id="1f3ef" class="javax.swing.JButton" binding="buttonRight">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="next"/>
+        </properties>
+      </component>
+      <component id="ac550" class="javax.swing.JButton" binding="zOutButton">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="-"/>
+        </properties>
+      </component>
+      <component id="bae65" class="javax.swing.JButton" binding="zInButton">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="+"/>
+        </properties>
+      </component>
+      <component id="85fbd" class="javax.swing.JButton" binding="rnavButton">
+        <constraints>
+          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="---&gt;"/>
+        </properties>
+      </component>
+      <component id="ef882" class="javax.swing.JButton" binding="lnavButton">
+        <constraints>
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="&lt;---"/>
         </properties>
       </component>
     </children>


### PR DESCRIPTION
Added navigational buttons to the bar chart, which makes it easier to move around within the trace. Currently the navigation gets noticably slower whenever more than 100.000 elements of the trace have to be drawn. This might be addressed later on by drawing less elements, since there is no gain from having that many elements on screen at once.