### PR TITLE
Bar chart improvements

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -7,19 +7,9 @@
       <option name="url" value="https://repo1.maven.org/maven2" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="jboss.community" />
-      <option name="name" value="JBoss Community repository" />
-      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="MavenRepo" />
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven" />
-      <option name="name" value="maven" />
-      <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/releases" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="BintrayJCenter" />
@@ -32,9 +22,9 @@
       <option name="url" value="http://titania.fs.uni-saarland.de/nexus/content/groups/public/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="maven" />
-      <option name="name" value="maven" />
-      <option name="url" value="https://titania.fs.uni-saarland.de/nexus/content/groups/public/" />
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/releases" />
     </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation fileTree(dir: 'src/main/lib', include: ['*.jar'])
     implementation "de.unisb.cs.st:sequitur:1.0"
-    // https://mvnrepository.com/artifact/jfree/jfreechart
-    implementation group: 'jfree', name: 'jfreechart', version: '1.0.12'
+    // https://mvnrepository.com/artifact/org.jfree/jfreechart
+    compile group: 'org.jfree', name: 'jfreechart', version: '1.0.19'
     //implementation files("${System.getProperty('java.home')}/../lib/tools.jar")
 }
 

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/ChunkTrunk.java
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/ChunkTrunk.java
@@ -1,0 +1,90 @@
+package se.de.hu_berlin.informatik.vtdbg.coverage;
+
+import org.jfree.chart.ChartPanel;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import se.de.hu_berlin.informatik.vtdbg.coverage.view.SBFLScoreBarRenderer;
+
+import javax.swing.*;
+
+public class ChunkTrunk {
+    private XYSeriesCollection traceCollection;
+    private int[] start;
+    private int[] current;
+    private int[] end;
+    private int seriesid;
+
+    //creates chunks of elements from the ChartPanels stored inside a JTabbedPane
+    public ChunkTrunk(JTabbedPane tabs, int number, JLabel label) {
+        int maxChunkSize = 10000;
+        start = new int[number];
+        current = new int[number];
+        end = new int[number];
+        seriesid = 0;
+        traceCollection = new XYSeriesCollection();
+        for (int i = 0; i < number; i++){
+            start[i]=seriesid;
+            XYSeries series = ((XYSeriesCollection)((ChartPanel)tabs.getComponentAt(i)).getChart().getXYPlot().getDataset()).getSeries(0);
+            while (series.getItemCount() > maxChunkSize){
+                try {
+                    series.setKey("lines"+seriesid);
+                    traceCollection.addSeries(series.createCopy(0,maxChunkSize-1));
+                    series = series.createCopy(maxChunkSize, series.getItemCount()-1);
+                    seriesid++;
+                } catch (CloneNotSupportedException e) {
+                    e.printStackTrace();
+                }
+            }
+            if(series.getItemCount()>0){
+                series.setKey("lines"+seriesid);
+                traceCollection.addSeries(series);
+            }
+            end[i]=seriesid;
+            seriesid++;
+            current[i]=start[i];
+            updateChunk(tabs, i, label);
+        }
+    }
+
+    //updates the bar chart with a new chunk
+    private void updateChunk(JTabbedPane tabs, int i, JLabel label){
+        XYSeriesCollection temp = new XYSeriesCollection();
+        temp.addSeries(traceCollection.getSeries(current[i]));
+        float[] scores = new float[temp.getSeries(0).getItemCount()];
+        for(int j=0; j < temp.getSeries(0).getItemCount();j++){
+            scores[j]=temp.getSeries(0).getY(j).floatValue();
+        }
+        ((SBFLScoreBarRenderer)((ChartPanel)tabs.getComponentAt(i)).getChart().getXYPlot().getRenderer()).scores = scores;
+        ((ChartPanel)tabs.getComponentAt(i)).getChart().getXYPlot().setDataset(temp);
+        updateLabel(tabs, i, label);
+        ((ChartPanel)tabs.getComponentAt(i)).restoreAutoDomainBounds();
+    }
+
+    //updates the label that shows which chunk of elements the user currently sees
+    public void updateLabel(JTabbedPane tabs, int i, JLabel label){
+        int number1 = current[i]-start[i]+1;
+        int number2 = end[i]-start[i]+1;
+        label.setText("Chunk "+number1+"/"+number2);
+    }
+
+
+    public void nextChunk(JTabbedPane tabs, JLabel label) {
+        int i = tabs.getSelectedIndex();
+        if (i > -1) {
+            if (current[i] < end[i]){
+                current[i]++;
+                updateChunk(tabs, i, label);
+            }
+        }
+    }
+
+    public void previousChunk(JTabbedPane tabs, JLabel label) {
+        int i = tabs.getSelectedIndex();
+        if (i > -1) {
+            if (current[i] > start[i]){
+                current[i]--;
+                updateChunk(tabs, i, label);
+            }
+        }
+    }
+}

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/runner/MyCoverageExecutor.java
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/runner/MyCoverageExecutor.java
@@ -12,7 +12,6 @@ import se.de.hu_berlin.informatik.vtdbg.coverage.MyCoverageBundle;
 import javax.swing.*;
 
 public class MyCoverageExecutor extends Executor {
-
   public static final String EXECUTOR_ID = "MyCoverage";
 
   @Override

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/SBFLScoreBarRenderer.java
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/SBFLScoreBarRenderer.java
@@ -1,6 +1,7 @@
 package se.de.hu_berlin.informatik.vtdbg.coverage.view;
 
 import org.jfree.chart.renderer.xy.XYBarRenderer;
+import org.jfree.data.xy.XYDataset;
 
 import java.awt.*;
 
@@ -9,9 +10,7 @@ public class SBFLScoreBarRenderer extends XYBarRenderer {
     private final float range;
     private float lowestScore;
     private float highestScore;
-    private float[] scores;
-    public int scstart;
-    public int scend;
+    public float[] scores;
 
     public SBFLScoreBarRenderer(float lowestScore, float highestScore, float[] scores) {
         this.lowestScore = lowestScore;
@@ -20,11 +19,20 @@ public class SBFLScoreBarRenderer extends XYBarRenderer {
         this.range = highestScore - lowestScore;
     }
 
+    /*public SBFLScoreBarRenderer(float lowestScore, float highestScore, XYDataset dataset){
+        this.range = highestScore - lowestScore;
+        this.lowestScore = lowestScore;
+        this.highestScore = highestScore;
+        scores = new float[dataset.getItemCount(0)];
+        for (int i = 0; i < dataset.getItemCount(0); i++){
+            scores[i] = (float) dataset.getYValue(0,i);
+        }
+    }*/
+
     public Paint getItemPaint(final int row, final int column) {
         // returns color depending on score, if existing
-        //enriklau: has been modified to update the colors accordingly when changing the view
         if (column >= 0 && column < scores.length) {
-            return getColor(scores[scstart + column]);
+            return getColor(scores[column]);
         } else {
             return Color.BLUE;
         }

--- a/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/TraceWindow.form
+++ b/src/main/java/se/de/hu_berlin/informatik/vtdbg/coverage/view/TraceWindow.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="se.de.hu_berlin.informatik.vtdbg.coverage.view.TraceWindow">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="9" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="603" height="464"/>
@@ -10,7 +10,7 @@
     <children>
       <tabbedpane id="34665" binding="tabs">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="6" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="8" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="200" height="200"/>
           </grid>
         </constraints>
@@ -20,7 +20,9 @@
       </tabbedpane>
       <component id="3e3df" class="javax.swing.JButton" binding="buttonLeft">
         <constraints>
-          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="129" height="30"/>
+          </grid>
         </constraints>
         <properties>
           <text value="previous"/>
@@ -28,42 +30,43 @@
       </component>
       <component id="1f3ef" class="javax.swing.JButton" binding="buttonRight">
         <constraints>
-          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="156" height="30"/>
+          </grid>
         </constraints>
         <properties>
           <text value="next"/>
         </properties>
       </component>
-      <component id="ac550" class="javax.swing.JButton" binding="zOutButton">
+      <hspacer id="67289">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
+      <component id="1e833" class="javax.swing.JLabel" binding="chunkLabel">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="-"/>
+          <text value="Chunk 1000000/1000000"/>
         </properties>
       </component>
-      <component id="bae65" class="javax.swing.JButton" binding="zInButton">
+      <component id="a8157" class="javax.swing.JButton" binding="chunkPrev">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="50" height="30"/>
+          </grid>
         </constraints>
         <properties>
-          <text value="+"/>
+          <text value="&lt;"/>
         </properties>
       </component>
-      <component id="85fbd" class="javax.swing.JButton" binding="rnavButton">
-        <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="---&gt;"/>
-        </properties>
-      </component>
-      <component id="ef882" class="javax.swing.JButton" binding="lnavButton">
+      <component id="856ec" class="javax.swing.JButton" binding="chunkNext">
         <constraints>
           <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="&lt;---"/>
+          <text value="&gt;"/>
         </properties>
       </component>
     </children>


### PR DESCRIPTION
-added a new class ChunkTrunk that splits the traces into chunks (of currently 10.000 elements each) and controls which chunk is being shown by the bar chart
-added navigational buttons and a label to navigate through the chunks (the label updates whenever a tab is selected or one of the navigational buttons is pressed)
-the bar chart is now navigable using the mouse
  -dragging left zooms out of the chart
  -dragging right selects a portion of the chart to zoom into
  -scrolling zooms in at the position of the cursor
  -ctrl+dragging navigates horizontally
  -alt+dragging selects columns, marks the corresponding lines of code and jumps into the code (also: fixed a bug that caused unintended lines to be marked in the code, because the separation of columns happened at the middle of a column, not the outer edges)

Code in the TraceWindow class not yet cleaned up in case major bugs surface.